### PR TITLE
Bump range for `adafruit-blinka` to <8.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -120,7 +120,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "3d718aec480a1f285df3b8068d8f69d56d3fb7dc56c3610927d3c6765aba3283"
+content-hash = "09e04c0d85906fb4207bafa4e7264bde4f1f464dc0172b1831bbcace79c0b922"
 
 [metadata.files]
 adafruit-blinka = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ include = [
 
 [tool.poetry.dependencies]
 python = "^3.6"
-adafruit-blinka = ">=5.5.1,<7.0"
+adafruit-blinka = ">=5.5.1,<8.0"
 adafruit-circuitpython-pca9685 = ">=3.3.2,<4.0"
 pigpio = ">=1.78,<2.0"
 python-singleton = ">=0.1.2,<1.0"


### PR DESCRIPTION
Version `7.0` for adafruit-blinka was released today. From looking at the changelog, it seems to be compatible. This will help prevent dependency conflicts, similar to #6.

The release notes mention the requirement for Python 3.7. It's not necessary to copy that here since pip can resolve and find a compatible version for either `3.6` or `3.7+`. With 3.6 it just wouldn't be the latest one.

/CC: @soldag

Release notes: https://github.com/adafruit/Adafruit_Blinka/releases/tag/7.0.0
Compare view: https://github.com/adafruit/Adafruit_Blinka/compare/6.20.4...7.0.0